### PR TITLE
Print test run times next to tests

### DIFF
--- a/src/reporters/specHelpers.js
+++ b/src/reporters/specHelpers.js
@@ -11,7 +11,7 @@ const XMARK = "✗";
 const spaces = length => Array.from({ length: length * 2 }).join(" ");
 
 function header(logger, group, level) {
-  const time = ""; //group.time ? `(${group.time} ms)` : '';
+  const time = group.time ? `(${group.time} ms)` : '';
   const label = `${spaces(level)} ${colors.bold(group.description)} ${time}`;
   decorateTopLevel(logger, label, level);
 }
@@ -34,13 +34,14 @@ function printResults(logger, group, level = 0) {
   header(logger, group, level);
 
   group.results.forEach(result => {
+    const time = result.time || result.time === 0 ? `(${result.time} ms)` : '';
     if (result.result === common.TEST_SUCCESS) {
       logger.log(
-        `${spaces(level + 1)} ${colors.green(CHECKMARK)} ${result.description}`
+        `${spaces(level + 1)} ${colors.green(CHECKMARK)} ${result.description} ${time}`
       );
     } else if (result.result === common.TEST_FAILURE) {
       logger.log(
-        `${spaces(level + 1)} ${colors.red(XMARK)} ${result.description}`
+        `${spaces(level + 1)} ${colors.red(XMARK)} ${result.description} ${time}`
       );
       logger.log(colors.red(result.details));
     }

--- a/tests/features/output-tests.js
+++ b/tests/features/output-tests.js
@@ -26,3 +26,12 @@ test("should handle broken tests", () => {
     }
   );
 });
+
+test('should print test times', () => {
+    return spawn("./bin/cli.js", ["tests/fixtures/passing-tests.js"]).then(
+      ({ stdout }) => {
+        const count = parseInt(stdout.match(/\((\d+) ms\)/g).length, 10);
+        assert.strictEqual(count, 7);
+      }
+    );
+});


### PR DESCRIPTION
This will print out the test run time for each test case and print the combined run time for the whole test file. The timing of tests was already implemented we just didn't show it in the output.

# Future improvements
Run times are measured with Date so the high resolution possible is milleseconds we might want to switch to `process.hrtime()` or `process.hrtime.bigint()` (introduced in node v10) to get nanosecond resolution on the timers.

Add run time for sub groups like `Feature` and `Scenario`.