### PR TITLE
Sub groups timings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuta",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/reporters/spec.js
+++ b/src/reporters/spec.js
@@ -80,7 +80,7 @@ function createSpecReporter(logger, fileCount, processCount, printErrorDetails) 
       if (summarizedResults.errors !== 0 || summarizedResults.sucessess !== 0) {
         const stringLogger = createStringLogger();
 
-        specHelpers.printResults(stringLogger, results);
+        specHelpers.printResults(stringLogger, results, 0, false);
         const currentOutput = stringLogger.getLog();
 
         if (!currentOutput) return;

--- a/src/reporters/specHelpers.js
+++ b/src/reporters/specHelpers.js
@@ -10,10 +10,17 @@ const XMARK = "✗";
 
 const spaces = length => Array.from({ length: length * 2 }).join(" ");
 
-function header(logger, group, level) {
-  const time = group.time ? `(${group.time} ms)` : '';
+function header(logger, group, level, includeTime) {
+  const time = includeTime && group.time !== null && group.time !== undefined ? `(${group.time} ms)` : "";
   const label = `${spaces(level)} ${colors.bold(group.description)} ${time}`;
   decorateTopLevel(logger, label, level);
+}
+
+function footer(logger, group, level) {
+  if (group.time !== null && group.time !== undefined) {
+    const label = `${spaces(level)} ${colors.bold(group.description)} (${group.time} ms)`;
+    logger.log(label);
+  }
 }
 
 function decorateTopLevel(logger, label, level) {
@@ -26,15 +33,15 @@ function isGroupEmpty(group) {
   return groupSummary.errors === 0 && groupSummary.successes === 0;
 }
 
-function printResults(logger, group, level = 0) {
+function printResults(logger, group, level = 0, includeTimeInHeader = true) {
   if (isGroupEmpty(group)) {
     return;
   }
 
-  header(logger, group, level);
+  header(logger, group, level, includeTimeInHeader);
 
   group.results.forEach(result => {
-    const time = result.time || result.time === 0 ? `(${result.time} ms)` : '';
+    const time = result.time || result.time === 0 ? `(${result.time} ms)` : "";
     if (result.result === common.TEST_SUCCESS) {
       logger.log(
         `${spaces(level + 1)} ${colors.green(CHECKMARK)} ${result.description} ${time}`
@@ -47,8 +54,14 @@ function printResults(logger, group, level = 0) {
     }
   });
 
-  group.groups.forEach(group => printResults(logger, group, level + 1));
+  group.groups.forEach(group => printResults(logger, group, level + 1, includeTimeInHeader));
+
+  if (!includeTimeInHeader) {
+    footer(logger, group, level);
+    group.time = null;
+  }
 }
+
 module.exports = {
   printResults
 };

--- a/tests/features/output-tests.js
+++ b/tests/features/output-tests.js
@@ -5,7 +5,7 @@ const { spawn } = require("../helpers/spawn");
 
 test("return exit code 0 for passing tests", () => {
   return spawn("./bin/cli.js", ["tests/fixtures/passing-tests.js"]).then(({ exitCode }) => {
-    assert.equal(exitCode, 0, "Exit code should be zero");
+    assert.strictEqual(exitCode, 0, "Exit code should be zero");
   });
 });
 
@@ -17,13 +17,62 @@ test("return non-zero exit code for failing tests", () => {
 
 test("should handle broken tests", () => {
   return spawn("./bin/cli.js", ["tests/fixtures/b0rked-test.js"]).then(({ exitCode }) => {
-    assert.equal(exitCode, 10);
+    assert.strictEqual(exitCode, 10);
   });
 });
 
-test("should print test times", () => {
+test("should print test times when running single file", () => {
   return spawn("./bin/cli.js", ["--reporter", "spec", "tests/fixtures/passing-tests.js"]).then(({ stdout }) => {
     const count = parseInt(stdout.match(/\((\d+) ms\)/g).length, 10);
-    assert.strictEqual(count, 7);
+    assert.strictEqual(count, 4);
+  });
+});
+
+test("should print test times when running tests in parallel", () => {
+  return spawn("./bin/cli.js", [
+    "--reporter",
+    "spec",
+    "-p",
+    "2",
+    "tests/fixtures/passing-tests.js",
+    "tests/fixtures/passing-tests.js",
+  ]).then(({ stdout }) => {
+    const count = parseInt(stdout.match(/\((\d+) ms\)/g).length, 10);
+    assert.strictEqual(count, 8);
+  });
+});
+
+test("should print test times for groups in bdd files", () => {
+  return spawn("./bin/cli.js", ["--reporter", "spec", "tests/fixtures/bdd-multiple-scenarios-file.js"]).then(
+    ({ stdout }) => {
+      const count = parseInt(stdout.match(/\((\d+) ms\)/g).length, 10);
+      assert.strictEqual(count, 15);
+
+      const featureTimes = parseInt(stdout.match(/Feature.*\((\d+) ms\)/g).length, 10);
+      assert.strictEqual(featureTimes, 2);
+
+      const scenarioTimes = parseInt(stdout.match(/Scenario.*\((\d+) ms\)/g).length, 10);
+      assert.strictEqual(scenarioTimes, 3);
+    }
+  );
+});
+
+test("should print test times for groups in bdd files in parallel", () => {
+  return spawn("./bin/cli.js", [
+    "--reporter",
+    "spec",
+    "-p",
+    "2",
+    "tests/fixtures/bdd-multiple-scenarios-file.js",
+    "tests/fixtures/passing-tests.js",
+  ]).then(({ stdout }) => {
+    const count = parseInt(stdout.match(/\((\d+) ms\)/g).length, 10);
+    assert.strictEqual(count, 19);
+
+    const featureTimes = parseInt(stdout.match(/Feature.*\((\d+) ms\)/g).length, 10);
+    assert.strictEqual(featureTimes, 2);
+
+    const scenarioTimes = parseInt(stdout.match(/Scenario.*\((\d+) ms\)/g).length, 10);
+    assert.strictEqual(scenarioTimes, 3);
   });
 });

--- a/tests/fixtures/bdd-multiple-scenarios-file.js
+++ b/tests/fixtures/bdd-multiple-scenarios-file.js
@@ -1,0 +1,83 @@
+const feature = require("../../src/bdd.js").feature;
+const assert = require("assert");
+const sinon = require("sinon");
+
+const testObject = {
+  method() {}
+};
+
+feature("single", scenario => {
+  scenario("only scenario", ({ before, after, given, when, then }) => {
+    let result = 42;
+    before(() => {
+      sinon.stub(testObject, "method");
+    });
+
+    after(() => {
+      testObject.method.restore();
+    });
+
+    given("a testMethod that returns 42", () => {
+      testObject.method.returns(42);
+    });
+
+    when("testMethod is called", () => {
+      result = testObject.method();
+    });
+
+    then("testMethod should have been calledOnce", () => {
+      sinon.assert.calledOnce(testObject.method);
+      assert.equal(42, result);
+    });
+  });
+});
+
+feature("double", scenario => {
+  scenario("first scenario", ({ before, after, given, when, then }) => {
+    let result = 42;
+    before(() => {
+      sinon.stub(testObject, "method");
+    });
+
+    after(() => {
+      testObject.method.restore();
+    });
+
+    given("a testMethod that returns 42", () => {
+      testObject.method.returns(42);
+    });
+
+    when("testMethod is called", () => {
+      result = testObject.method();
+    });
+
+    then("testMethod should have been calledOnce", () => {
+      sinon.assert.calledOnce(testObject.method);
+      assert.equal(42, result);
+    });
+  });
+
+  scenario("second scenario", ({ before, after, given, when, then }) => {
+    let result = 42;
+    before(() => {
+      sinon.stub(testObject, "method");
+    });
+
+    after(() => {
+      testObject.method.restore();
+    });
+
+    given("a testMethod that returns 42", () => {
+      testObject.method.returns(42);
+    });
+
+    when("testMethod is called", () => {
+      result = testObject.method();
+    });
+
+    then("testMethod should have been calledOnce", () => {
+      sinon.assert.calledOnce(testObject.method);
+      assert.equal(42, result);
+    });
+  });
+});


### PR DESCRIPTION
Fix bug causing test result to be printed twice when running tests using a single process.

Add timings for sub groups like 'Feature' and 'Scenario'. For multiple process run the timings will be printed next to the group name like this.
```
● tests/fixtures/bdd-multiple-scenarios-file.js (5 ms)
  Feature: a feature (3 ms)
    Scenario: first scenario (3 ms)
      ✓ Given a testMethod that returns 42 (1 ms)
      ✓ When testMethod is called (1 ms)
      ✓ Then testMethod should have been calledOnce (0 ms)
  Feature: a second feature (2 ms)
    Scenario: first scenario (1 ms)
      ✓ Given a testMethod that returns 42 (0 ms)
      ✓ When testMethod is called (1 ms)
      ✓ Then testMethod should have been calledOnce (0 ms)
    Scenario: second scenario (1 ms)
      ✓ Given a testMethod that returns 42 (0 ms)
      ✓ When testMethod is called (0 ms)
      ✓ Then testMethod should have been calledOnce (0 ms) 
```

For single process runs the timings will be printed after the group has finished like this
```
● tests/fixtures/bdd-multiple-scenarios-file.js 
  Feature: a feature 
    Scenario: first scenario 
      ✓ Given a testMethod that returns 42 (0 ms)
      ✓ When testMethod is called (1 ms)
      ✓ Then testMethod should have been calledOnce (1 ms)
    Scenario: first scenario (4 ms)
  Feature: a feature (4 ms)
  Feature: a second feature 
    Scenario: first scenario 
      ✓ Given a testMethod that returns 42 (0 ms)
      ✓ When testMethod is called (1 ms)
      ✓ Then testMethod should have been calledOnce (0 ms)
    Scenario: first scenario (1 ms)
    Scenario: second scenario 
      ✓ Given a testMethod that returns 42 (1 ms)
      ✓ When testMethod is called (1 ms)
      ✓ Then testMethod should have been calledOnce (0 ms)
    Scenario: second scenario (2 ms)
  Feature: a second feature (3 ms)
 tests/fixtures/bdd-multiple-scenarios-file.js (8 ms)
 ```