### PR TITLE
Make sure kuta exits after closing all child process on SIGINT

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ const processPool = require(path.join(__dirname, "../src/process-pool"));
 const EXIT_CODE_OK = 0;
 const EXIT_CODE_USAGE = 1;
 const EXIT_CODE_FAILURES = 2;
+const EXIT_CODE_STOPPED = 3;
 
 const DEFAULT_TIMEOUT = 2000;
 
@@ -169,8 +170,10 @@ function runTests() {
 }
 
 process.on("SIGINT", () => {
-  logger.log("caught SIGINT, stopping child processes");
+  logger.log("caught SIGINT, stopping child processes...");
   processPool.stopProcessPool();
+  logger.log("child processes stopped, exit kuta");
+  process.exit(EXIT_CODE_STOPPED);
 });
 
 if (require.main === module) {


### PR DESCRIPTION
When sending a SIGINT to kuta during a test run it stops all child process but never exits so the kuta process stays alive forever and you need to use `kill` to close it.

This adds a process exit after all child process has been stopped so kuta will exit as well. 