### PR TITLE
Make after each only fail the current scope

### DIFF
--- a/src/kuta.js
+++ b/src/kuta.js
@@ -109,8 +109,17 @@ function createEachHook(befores = [], afters = []) {
     runIn(test) {
       return arrayAsPromise(befores)
         .then(test)
-        .then(result => {
-          return arrayAsPromise(afters).then(() => result);
+        .then((result) => {
+          return arrayAsPromise(afters)
+            .then(() => result)
+            .catch((err) => {
+              if (result.result === common.TEST_SKIPPED) return result;
+
+              return Object.assign({}, result, {
+                result: common.TEST_FAILURE,
+                details: err.stack,
+              });
+            });
         });
     },
     extend(_befores, _afters) {

--- a/tests/features/grouping.js
+++ b/tests/features/grouping.js
@@ -4,46 +4,58 @@ const assert = require("assert");
 const { spawn } = require("../helpers/spawn");
 
 test("lifecycle hooks should run in correct order", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/lifecycles.js"]).then(({ stdout }) => {
-    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-    assert.equal(failedCount, 0, "Should be zero failing tests");
-    assert.equal(passedCount, 1, "Should be one passing test");
-  });
+  return spawn("./bin/cli.js", ["tests/fixtures/lifecycles.js"]).then(
+    ({ stdout }) => {
+      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+      assert.equal(failedCount, 0, "Should be zero failing tests");
+      assert.equal(passedCount, 1, "Should be one passing test");
+    }
+  );
 });
 
 test("exceptions in before mark tests in group failed", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-group.js"]).then(({ stdout }) => {
-    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-    assert.equal(failedCount, 2, "Should be two failing tests");
-    assert.equal(passedCount, 1, "Should be one passing tests");
-  });
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-group.js"]).then(
+    ({ stdout }) => {
+      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+      assert.equal(failedCount, 2, "Should be two failing tests");
+      assert.equal(passedCount, 1, "Should be one passing tests");
+    }
+  );
 });
 
 test("exceptions in after mark tests in group failed", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-after.js"]).then(({ stdout }) => {
-    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-    assert.equal(failedCount, 2, "Should be two failing tests");
-    assert.equal(passedCount, 1, "Should be one passing tests");
-  });
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-after.js"]).then(
+    ({ stdout }) => {
+      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+      assert.equal(failedCount, 2, "Should be two failing tests");
+      assert.equal(passedCount, 1, "Should be one passing tests");
+    }
+  );
 });
+
 
 test("should bail on first fail in scenarios", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-scenario.js"]).then(({ stdout }) => {
-    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-    assert.equal(failedCount, 2);
-    assert.equal(passedCount, 5);
-  });
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-scenario.js"]).then(
+    ({ stdout }) => {
+      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+      assert.equal(failedCount, 2);
+      assert.equal(passedCount, 5);
+    }
+  );
 });
 
+
 test("exceptions in afterEach mark test as failed and bails early", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-afterEach-scenario.js"]).then(({ stdout }) => {
-    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-    assert.equal(failedCount, 1, "Should be one failing tests");
-    assert.equal(passedCount, 0, "Should be one passing tests");
-  });
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-afterEach-scenario.js"]).then(
+    ({ stdout }) => {
+      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+      assert.equal(failedCount, 1, "Should be one failing tests");
+      assert.equal(passedCount, 0, "Should be one passing tests");
+    }
+  );
 });

--- a/tests/features/grouping.js
+++ b/tests/features/grouping.js
@@ -4,34 +4,46 @@ const assert = require("assert");
 const { spawn } = require("../helpers/spawn");
 
 test("lifecycle hooks should run in correct order", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/lifecycles.js"]).then(
-    ({ stdout }) => {
-      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-      assert.equal(failedCount, 0, "Should be zero failing tests");
-      assert.equal(passedCount, 1, "Should be one passing test");
-    }
-  );
+  return spawn("./bin/cli.js", ["tests/fixtures/lifecycles.js"]).then(({ stdout }) => {
+    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+    assert.equal(failedCount, 0, "Should be zero failing tests");
+    assert.equal(passedCount, 1, "Should be one passing test");
+  });
 });
 
-test("exceptions in befores/afters mark tests in group failed", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-group.js"]).then(
-    ({ stdout }) => {
-      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-      assert.equal(failedCount, 2, "Should be two failing tests");
-      assert.equal(passedCount, 1, "Should be one passing tests");
-    }
-  );
+test("exceptions in before mark tests in group failed", () => {
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-group.js"]).then(({ stdout }) => {
+    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+    assert.equal(failedCount, 2, "Should be two failing tests");
+    assert.equal(passedCount, 1, "Should be one passing tests");
+  });
+});
+
+test("exceptions in after mark tests in group failed", () => {
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-after.js"]).then(({ stdout }) => {
+    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+    assert.equal(failedCount, 2, "Should be two failing tests");
+    assert.equal(passedCount, 1, "Should be one passing tests");
+  });
 });
 
 test("should bail on first fail in scenarios", () => {
-  return spawn("./bin/cli.js", ["tests/fixtures/failing-scenario.js"]).then(
-    ({ stdout }) => {
-      const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
-      const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
-      assert.equal(failedCount, 2);
-      assert.equal(passedCount, 5);
-    }
-  );
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-scenario.js"]).then(({ stdout }) => {
+    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+    assert.equal(failedCount, 2);
+    assert.equal(passedCount, 5);
+  });
+});
+
+test("exceptions in afterEach mark test as failed and bails early", () => {
+  return spawn("./bin/cli.js", ["tests/fixtures/failing-afterEach-scenario.js"]).then(({ stdout }) => {
+    const failedCount = parseInt(stdout.match(/Failed.*(\d)/)[1], 10);
+    const passedCount = parseInt(stdout.match(/Passed.*(\d)/)[1], 10);
+    assert.equal(failedCount, 1, "Should be one failing tests");
+    assert.equal(passedCount, 0, "Should be one passing tests");
+  });
 });

--- a/tests/fixtures/failing-after.js
+++ b/tests/fixtures/failing-after.js
@@ -1,0 +1,13 @@
+const test = require("../../src/kuta.js").test;
+
+test("a top level test", () => {});
+
+test.group("grouped tests", (t) => {
+  t.after(() => {
+    throw new Error("");
+  });
+
+  t("inner test 1", () => {});
+
+  t("inner test 2", () => {});
+});

--- a/tests/fixtures/failing-afterEach-scenario.js
+++ b/tests/fixtures/failing-afterEach-scenario.js
@@ -1,0 +1,13 @@
+const { afterEach, Feature, Scenario, Given, When, Then } = require("../../src/mocha-compat.js");
+
+Feature("a mocha cakes feature", () => {
+  Scenario("cakes scenario", () => {
+    afterEach(() => {
+      throw new Error("");
+    });
+
+    Given("this fails", () => {});
+    When("this is skipped", () => {});
+    Then("this is skipped", () => {});
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/daniel-lundin/kuta/issues/28

Currently `afterEach` fails all tests within the scope even if it's just after a specific part of the scope. This updates `afterEach` to fail the result was created right before it ran instead of the whole scope. 